### PR TITLE
Feat: Update tools

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - experiment/**/**/**
     paths:
       - src/**
       - .github/workflows/build-and-push.yml
@@ -24,7 +25,7 @@ jobs:
             dockerReadmePath: src/DOCKER_README.md
             dockerShortDescription: Devcontainer for PlantUML design workloads
             containerName: plantuml-devcontainer
-            containerTag: 1.0.1
+            containerTag: 1.0.3
             username: plantuml
             additionalFilesToWatch: src/**
 

--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -14,8 +14,18 @@ ENV SHELL /bin/bash
 RUN apt update && apt upgrade -y && apt install \
   git \
   curl \
-  vim \
+  wget \
   -y 
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
+
+RUN apt remove -y wget
 
 RUN echo "root:$ROOT_PASS" | chpasswd
 RUN useradd -m $USERNAME


### PR DESCRIPTION
- Replace 'vim' with 'nvim'. This is done because nvim can act as a
  server for vscode.
- Add branch `experiment/**/**/**` to `build-and-push.sh` workflow.
  These series of branches are used for short experiments to see if
  something works as expected.
- Upgrade container version by patch.
